### PR TITLE
Merging of function sections

### DIFF
--- a/src/Object.zig
+++ b/src/Object.zig
@@ -394,8 +394,8 @@ fn Parser(comptime ReaderType: type) type {
 
                             const init_len = try readLeb(u32, reader);
                             const init_data = try gpa.alloc(u8, init_len);
-                            data.data = init_data;
                             try reader.readNoEof(init_data);
+                            data.data = init_data;
                         }
                         self.object.data.end = self.reader.bytes_read;
                         try assertEnd(reader);

--- a/src/Wasm.zig
+++ b/src/Wasm.zig
@@ -1,0 +1,77 @@
+//! Wasm represents the final binary
+const Wasm = @This();
+
+const std = @import("std");
+const Object = @import("Object.zig");
+const spec = @import("spec.zig");
+const fs = std.fs;
+const Allocator = std.mem.Allocator;
+
+gpa: *Allocator,
+/// The binary file that we will write the final binary data to
+file: fs.File,
+/// A list with references to objects we link to during `flush()`
+objects: std.ArrayListUnmanaged(Object) = .{},
+/// Merged globals will be appended to this list
+globals: std.ArrayListUnmanaged(spec.sections.Global) = .{},
+/// Merged function sections are appended to this list
+funcs: std.ArrayListUnmanaged(spec.sections.Func) = .{},
+
+/// Initializes a new wasm binary file at the given path.
+/// Will overwrite any existing file at said path.
+pub fn openPath(gpa: *Allocator, path: []const u8) !Wasm {
+    const file = try fs.cwd().createFile(path, .{
+        .truncate = true,
+        .read = true,
+    });
+    errdefer file.close();
+
+    return .{ .gpa = gpa, .file = file };
+}
+
+/// Releases any resources that is owned by `Wasm`,
+/// usage after calling deinit is illegal behaviour.
+pub fn deinit(self: *Wasm) void {
+    for (self.objects.items) |object| {
+        object.file.close();
+        object.deinit(self.gpa);
+    }
+    self.objects.deinit(self.gpa);
+    self.file.close();
+    self.* = undefined;
+}
+
+/// Parses objects from the given paths as well as append them to `self`
+pub fn addObjects(self: *Wasm, file_paths: []const []const u8) !void {
+    errdefer for (self.objects.items) |object| {
+        object.file.close();
+        object.deinit(self.gpa);
+    } else self.objects.deinit(self.gpa);
+
+    for (file_paths) |path| {
+        const file = fs.cwd().openFile(path, .{});
+        errdefer file.close();
+        var object = try Object.init(self.gpa, file);
+        errdefer object.deinit(self.gpa);
+        try self.objects.append(self.gpa, object);
+    }
+}
+
+/// Flushes the `Wasm` construct into a final wasm binary by linking
+/// the objects, ensuring the final binary file has no collisions.
+pub fn flush(self: *Wasm) !void {
+    try self.mergeFunctions();
+}
+
+/// Merges all function sections into the final binary, and patches 
+fn mergeFunctions(self: *Wasm) !void {
+    for (self.objects.items) |object| {
+        const func_sections: Object.SectionData(spec.sections.Func) = object.funcs;
+        if (func_sections.isEmpty()) continue;
+
+        for (func_sections) |func| {
+            const id = @intCast(u32, self.funcs.items.len);
+            try self.funcs.append(self.gpa, func);
+        }
+    }
+}

--- a/src/spec.zig
+++ b/src/spec.zig
@@ -179,12 +179,13 @@ pub const sections = struct {
     };
 
     pub const Code = struct {
-        pub const Local = struct {
-            valtype: ValueType,
-            count: u32,
-        };
-        locals: []const Local,
-        body: []const Instruction,
+        data: []u8,
+        // pub const Local = struct {
+        //     valtype: ValueType,
+        //     count: u32,
+        // };
+        // locals: []const Local,
+        // body: []const Instruction,
     };
 
     pub const Data = struct {
@@ -304,6 +305,17 @@ pub const Relocation = struct {
             };
         }
     };
+
+    /// Verifies the relocation type of a given `Relocation` and returns
+    /// true when the relocation references a function call or address to a function.
+    pub fn isFunction(self: Relocation) bool {
+        return switch (self.relocation_type) {
+            .R_WASM_FUNCTION_INDEX_LEB,
+            .R_WASM_TABLE_INDEX_SLEB,
+            => true,
+            else => false,
+        };
+    }
 
     pub fn format(self: Relocation, comptime fmt: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
         _ = fmt;

--- a/src/spec.zig
+++ b/src/spec.zig
@@ -50,15 +50,12 @@ fn MergedEnum(comptime T: type, comptime fields: []const TypeInfo.EnumField) typ
         @compileError("Given type 'T' must be an enum type but instead was given: " ++ @typeName(T));
     }
 
-    const old_fields = std.meta.fields(T);
-    var new_fields: [fields.len + old_fields.len]TypeInfo.EnumField = undefined;
-    std.mem.copy(TypeInfo.EnumField, &new_fields, old_fields);
-    std.mem.copy(TypeInfo.EnumField, new_fields[old_fields.len..], fields);
+    const new_fields = std.meta.fields(T) ++ fields;
 
     return @Type(.{ .Enum = .{
         .layout = .Auto,
         .tag_type = u8,
-        .fields = &new_fields,
+        .fields = new_fields,
         .decls = &.{},
         .is_exhaustive = false,
     } });


### PR DESCRIPTION
Closes #7 
PR to track progress on merging of functions.

Merging of the function sections requires the re-numbering of functions. This requires modification to code sections at each location where a function index is embedded, such as `call <id>` (calling a function) and `i32_const <id>` (address of a function). Each such location is stored as padded leb128 to remain a fixed size, and we can patch such values without resizing the code section.
Each instruction mentioned above, will contain a `reloc` of kind `R_WASM_FUNCTION_INDEX_LEB` or `R_WASM_TABLE_INDEX_SLEB`. As the reloc contains the offset within the target section (in this case, the code section). We can simply store the entire code section as bytes, and overwrite a fixed-size leb128 with the new function index.
